### PR TITLE
Add Git config files .GitAttribs and .GitIgnore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+*.cwproj text eol=crlf
+*.clw text eol=crlf
+*.inc text eol=crlf
+*.[Ii][Nn][Cc] text eol=crlf
+*.trn text eol=crlf
+*.exp text eol=crlf
+*.[Ii][Nn][Ii] text eol=crlf
+*.txa text eol=crlf
+*.[Tt][Xx][Aa] text eol=crlf
+
+
+# Denote all files that are truly binary and should not be modified.
+*.bmp binary
+*.[Bb][Mm][Pp] binary
+*.ico binary
+*.[Ii][Cc][Oo] binary
+*.app binary
+*.[Aa][Pp][Pp] binary
+*.dct binary
+*.[Dd][Cc][Tt] binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+map/
+obj/
+*.cache
+*.bak
+*.[Bb][Aa][Kk]
+*.lnk
+*.[Ll][Nn][Kk]


### PR DESCRIPTION
.GitAttribs makes the ZIP file with correct 13,10 line endings for Windows

.GitIgnore - leave out some build files and folders (Map/Obj) .LNK are shortcut files I often have

Copied from Mark Sarson Legacy2ABC